### PR TITLE
only upload a single sdist

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -3,7 +3,7 @@ name: Build and publish to PyPI
 on:
   push:
     tags:
-      - "v*"  # Trigger on version tags like v0.1.0
+      - "v*"
   workflow_dispatch:
 
 jobs:
@@ -15,6 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CIBW_BUILD: "cp311-* cp312-* cp313-* cp314-*"
+
     steps:
       - uses: actions/checkout@v4
 
@@ -39,6 +40,7 @@ jobs:
           cibuildwheel --output-dir wheelhouse
 
       - name: Build source distribution
+        if: matrix.os == 'ubuntu-latest'
         shell: bash -l {0}
         run: |
           python -m build --sdist --outdir wheelhouse


### PR DESCRIPTION
ok, pretty sweet to see the wheels get built and pushed correctly. Only problem is the last release failed because the recipe tries to upload the sdist on each platform but pypi rejects if it already exists. This PR makes it so that only linux pushes the dist on release

i think this will require a new release to run though