### PR TITLE
GHA: simplify docs building action

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,10 +1,17 @@
- name: Build Docs
- on:
-   push:
-     branches:
-     - main
+---
+name: Build Docs
 
- jobs:
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Manual Doc Build
+        default: run-doc-build
+        required: false
+
+jobs:
    docs:
      name: Build & Push Docs
      runs-on: ${{ matrix.os }}
@@ -23,7 +30,7 @@
          uses: actions/checkout@v6
          with:
            fetch-depth: 0 # Fetch all history for all branches and tags.
- 
+
        - name: Setup micromamba
          uses: mamba-org/setup-micromamba@v2
          with:
@@ -36,22 +43,9 @@
        - name: Make Docs
          run: cd docs; make html
 
-       - name: Commit Docs
-         run: |
-           git clone https://github.com/ammaraskar/sphinx-action-test.git --branch gh-pages --single-branch gh-pages
-           cp -r docs/_build/html/* gh-pages/
-           cd gh-pages
-           git config --local user.email "action@github.com"
-           git config --local user.name "GitHub Action"
-           git add .
-           git commit -m "Update documentation" -a || true
-           # The above command will fail if no changes were present,
-           # so we ignore the return code.
-
-       - name: Push to gh-pages
-         uses: ad-m/github-push-action@master
+       - name: Publish to Github Pages
+         uses: peaceiris/actions-gh-pages@v4
          with:
-            branch: gh-pages
-            directory: gh-pages
-            github_token: ${{ secrets.GITHUB_TOKEN }}
-            force: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html/
+          keep_files: false


### PR DESCRIPTION
I know the original is taken from some pysal example and I honestly have no idea why we are/were doing it over there that way. But this is what currently powers gwlearn's docs and it does not give contribution credit to the author of that random repository we clone in there for no reason.