### PR TITLE
`plot_matrix` keyword removal  – `utils.adjacency_matrix()`

### DIFF
--- a/pandarm/utils.py
+++ b/pandarm/utils.py
@@ -29,7 +29,7 @@ def reindex(series1, series2):
     return df.right
 
 
-def adjacency_matrix(edges_df, plot_matrix=False):  # noqa: ARG001 - Unused function argument: `plot_matrix`
+def adjacency_matrix(edges_df):
     df = pd.crosstab(edges_df["from"], edges_df["to"])
     idx = df.columns.union(df.index)
     df = df.reindex(index=idx, columns=idx, fill_value=0)


### PR DESCRIPTION
This PR resolves #39