### PR TITLE
adjust build-wheels for trusted publisher

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build_wheels:
     name: Build and publish wheels
+    permissions:
+      id-token: write  # MANDATORY for trusted publishing to PyPI
+      contents: write  # MANDATORY for the Github release action
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -53,9 +56,6 @@ jobs:
 
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags/')
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         shell: bash -l {0}
         run: |
           twine upload wheelhouse/*


### PR DESCRIPTION
## adjust build-wheels for trusted publisher

* this may not work since it is a different building wheels than what we do in normal pysal -- e.g. [here in `spopt`](https://github.com/pysal/spopt/blob/600b8a78a0353b6e88f0114938fa2f35e984e0ea/.github/workflows/release_and_publish.yml#L44C1-L45C53)
* if it does not work when we attempt release we can revert this change and remove the trusted publisher on PyPI