### PR TITLE
BUG: fix CRS retrieval from hdf5

### DIFF
--- a/pandarm/loaders/pandash5.py
+++ b/pandarm/loaders/pandash5.py
@@ -84,7 +84,7 @@ def network_from_pandas_hdf5(cls, filename):
     with pd.HDFStore(filename) as store:
         nodes = store["nodes"]
         edges = store["edges"]
-        crs = store["crs"].values[0] if "crs" in store.keys() else None  # noqa: SIM118 (this is not a dict)
+        crs = store["crs"].values[0] if hasattr(store, "crs") else None
         if "edges_geom_type" in store:
             geometry = shapely.from_ragged_array(
                 shapely.GeometryType(int(store["edges_geom_type"].item())),

--- a/tests/test_osm.py
+++ b/tests/test_osm.py
@@ -30,7 +30,6 @@ def test_save_hdf_with_geoms(osm_network, tmpfile):
     with pd.HDFStore(tmpfile) as store:
         assert store["nodes"].shape[0] >= 42691
 
-    with pytest.no_crs_warning:
-        roundtrip_net = pdna.Network.from_hdf5(tmpfile)
+    roundtrip_net = pdna.Network.from_hdf5(tmpfile)
 
     assert_frame_equal(osm_network.nodes_df, roundtrip_net.nodes_df)

--- a/tests/test_pandash5.py
+++ b/tests/test_pandash5.py
@@ -102,8 +102,7 @@ def test_network_to_pandas_hdf5_removal(tmpfile, network, impedance_names, two_w
 
 def test_network_from_pandas_hdf5(tmpfile, network, nodes, edges_df, impedance_names, two_way):
     ph5.network_to_pandas_hdf5(network, tmpfile)
-    with pytest.no_crs_warning:
-        new_net = ph5.network_from_pandas_hdf5(Network, tmpfile)
+    new_net = ph5.network_from_pandas_hdf5(Network, tmpfile)
     new_net.nodes_df = new_net.nodes_df
 
     assert_frame_equal(new_net.nodes_df.drop(columns="geometry"), nodes)
@@ -114,8 +113,7 @@ def test_network_from_pandas_hdf5(tmpfile, network, nodes, edges_df, impedance_n
 
 def test_network_save_load_hdf5(tmpfile, network, impedance_names, two_way, rm_nodes):
     network.save_hdf5(tmpfile, rm_nodes)
-    with pytest.no_crs_warning:
-        new_net = Network.from_hdf5(tmpfile)
+    new_net = Network.from_hdf5(tmpfile)
 
     nodes, edges = ph5.remove_nodes(network, rm_nodes)
     new_net.nodes_df = new_net.nodes_df


### PR DESCRIPTION
At the moment, even if crs is stored in hdf5, it iread as None. The reason is that  `"crs" in store.keys()` always returns False because `store.keys()` returns `['/crs', '/edges', '/edges_coords', '/edges_geom_type', '/edges_offsets', '/impedance_names', '/nodes', '/two_way']` - notice the / at the beginning. 