### PR TITLE
ENH: add k_nearest_nodes search

### DIFF
--- a/pandarm/network.py
+++ b/pandarm/network.py
@@ -624,7 +624,7 @@ class Network:
             nodes reachable within this distance. This will usually be a
             distance unit in meters however if you have customized the
             impedance (using the ``imp_name`` option) this could be in other
-            units such as utility or time.
+            units such as utility or time. Radius 0 is treated as infinity.
         imp_name : string, optional
             The impedance name to use for the query on this network.
             Must be one of the impedance names passed in the constructor of

--- a/pandarm/network.py
+++ b/pandarm/network.py
@@ -608,6 +608,50 @@ class Network:
             .query(f"{imp_name} <= {radius}")
         )
 
+    def k_nearest_nodes(self, nodes, k, max_radius, imp_name=None):
+        """
+        For each source node, return the *k* closest nodes in the network,
+        searching up to *max_radius*.
+
+        Parameters
+        ----------
+        nodes : list-like of ints
+            Source node IDs.
+        k : int
+            Number of nearest nodes to return per source node.
+        max_radius : float
+            Maximum travel distance to search within. Results are limited to
+            nodes reachable within this distance. This will usually be a
+            distance unit in meters however if you have customized the
+            impedance (using the ``imp_name`` option) this could be in other
+            units such as utility or time.
+        imp_name : string, optional
+            The impedance name to use for the query on this network.
+            Must be one of the impedance names passed in the constructor of
+            this object. If not specified, there must be only one impedance
+            passed in the constructor, which will be used.
+
+        Returns
+        -------
+        d : pandas.DataFrame
+            A dataframe with columns ``source``, ``destination``, and the
+            impedance name.  Each row represents one of the *k* nearest
+            reachable nodes for the corresponding source, sorted by ascending
+            distance within each source group.
+        """
+        imp_num = self._imp_name_to_num(imp_name)
+        imp_name = self.impedance_names[imp_num]
+        ext_ids = self.node_idx.index.values
+
+        dists, ids = self.net.k_nearest_nodes(nodes, k, max_radius, ext_ids, imp_num)
+        # dists and ids are both (len(nodes), k) arrays
+        rows = []
+        for i, src in enumerate(nodes):
+            for j in range(k):
+                if ids[i, j] != -1:
+                    rows.append((src, ids[i, j], dists[i, j]))
+        return pd.DataFrame(rows, columns=["source", "destination", imp_name])
+
     def _imp_name_to_num(self, imp_name):
         if imp_name is None:
             assert (

--- a/src/accessibility.cpp
+++ b/src/accessibility.cpp
@@ -84,7 +84,7 @@ Accessibility::precomputeRangeQueries(float radius) {
 
 
 vector<vector<pair<int64_t, float>>>
-Accessibility::Range(vector<int64_t> srcnodes, float radius, int64_t graphno, 
+Accessibility::Range(vector<int64_t> srcnodes, float radius, int64_t graphno,
                      vector<int64_t> ext_ids) {
 
     // Set up a mapping between the external node ids and internal ones
@@ -92,7 +92,7 @@ Accessibility::Range(vector<int64_t> srcnodes, float radius, int64_t graphno,
     for (int64_t i = 0; i < ext_ids.size(); i++) {
         int_ids.insert(pair<int64_t, int64_t>(ext_ids[i], i));
     }
-    
+
     // use cached results if available
     vector<DistanceVec> dists(srcnodes.size());
     if (dmsradius > 0 && radius <= dmsradius) {
@@ -108,7 +108,7 @@ Accessibility::Range(vector<int64_t> srcnodes, float radius, int64_t graphno,
                 omp_get_thread_num(), dists[i]);
         }
     }
-    
+
     // todo: check that results are returned from cache correctly
     // todo: check that performing an aggregation creates cache
 
@@ -117,10 +117,38 @@ Accessibility::Range(vector<int64_t> srcnodes, float radius, int64_t graphno,
     for (int64_t i = 0; i < dists.size(); i++) {
         output[i].resize(dists[i].size());
         for (int64_t j = 0; j < dists[i].size(); j++) {
-            output[i][j] = std::make_pair(ext_ids[dists[i][j].first], 
+            output[i][j] = std::make_pair(ext_ids[dists[i][j].first],
                                           dists[i][j].second);
         }
     }
+    return output;
+}
+
+
+vector<vector<pair<int64_t, float>>>
+Accessibility::KNearestNodes(vector<int64_t> srcnodes, int64_t k, double max_radius,
+                             int64_t graphno, vector<int64_t> ext_ids) {
+
+    // Build mapping from external id -> internal index
+    std::unordered_map<int64_t, int64_t> int_ids(ext_ids.size());
+    for (int64_t i = 0; i < (int64_t)ext_ids.size(); i++) {
+        int_ids.insert(pair<int64_t, int64_t>(ext_ids[i], i));
+    }
+
+    vector<vector<pair<int64_t, float>>> output(srcnodes.size());
+
+    #pragma omp parallel
+    #pragma omp for schedule(guided)
+    for (int64_t i = 0; i < (int64_t)srcnodes.size(); i++) {
+        DistanceVec nearest = ga[graphno]->KNearest(
+            int_ids[srcnodes[i]], k, max_radius, omp_get_thread_num());
+
+        output[i].resize(nearest.size());
+        for (int64_t j = 0; j < (int64_t)nearest.size(); j++) {
+            output[i][j] = make_pair(ext_ids[nearest[j].first], nearest[j].second);
+        }
+    }
+
     return output;
 }
 
@@ -141,7 +169,7 @@ Accessibility::Routes(vector<int64_t> sources, vector<int64_t> targets, int64_t 
     #pragma omp parallel
     #pragma omp for schedule(guided)
     for (int64_t i = 0 ; i < n ; i++) {
-        vector<NodeID> ret = this->ga[graphno]->Route(sources[i], targets[i], 
+        vector<NodeID> ret = this->ga[graphno]->Route(sources[i], targets[i],
             omp_get_thread_num());
         routes[i] = vector<int64_t> (ret.begin(), ret.end());
     }
@@ -156,17 +184,17 @@ Accessibility::Distance(int64_t src, int64_t tgt, int64_t graphno) {
 
 
 vector<double>
-Accessibility::Distances(vector<int64_t> sources, vector<int64_t> targets, int64_t graphno) {                       
-    
+Accessibility::Distances(vector<int64_t> sources, vector<int64_t> targets, int64_t graphno) {
+
     int64_t n = std::min(sources.size(), targets.size()); // in case lists don't match
     vector<double> distances(n);
-    
+
     #pragma omp parallel
     #pragma omp for schedule(guided)
     for (int64_t i = 0 ; i < n ; i++) {
         distances[i] = this->ga[graphno]->Distance(
-            sources[i], 
-            targets[i], 
+            sources[i],
+            targets[i],
             omp_get_thread_num());
     }
     return distances;
@@ -217,11 +245,11 @@ Accessibility::findNearestPOIs(int64_t srcnode, float maxradius, unsigned number
         maxradius, number, omp_get_thread_num());
 
     vector<distance_node_pair> distance_node_pairs;
-    std::map<POIKeyType, accessibility_vars_t>::iterator cat_for_pois = 
+    std::map<POIKeyType, accessibility_vars_t>::iterator cat_for_pois =
         accessibilityVarsForPOIs.find(cat);
     if(cat_for_pois == accessibilityVarsForPOIs.end())
         return distance_node_pairs;
-    
+
     accessibility_vars_t &vars = cat_for_pois->second;
 
     /* need to account for the possibility of having

--- a/src/accessibility.h
+++ b/src/accessibility.h
@@ -47,21 +47,26 @@ class Accessibility {
         int64_t graphno = 0);
 
     // get nodes with a range for a specific list of source nodes
-    vector<vector<pair<int64_t, float>>> Range(vector<int64_t> srcnodes, float radius, 
+    vector<vector<pair<int64_t, float>>> Range(vector<int64_t> srcnodes, float radius,
                                             int64_t graphno, vector<int64_t> ext_ids);
+
+    // get the k nearest nodes for a list of source nodes
+    vector<vector<pair<int64_t, float>>> KNearestNodes(vector<int64_t> srcnodes, int64_t k,
+                                                       double max_radius, int64_t graphno,
+                                                       vector<int64_t> ext_ids);
 
     // shortest path between two points
     vector<int64_t> Route(int64_t src, int64_t tgt, int64_t graphno = 0);
 
     // shortest path between list of origins and destinations
-    vector<vector<int64_t>> Routes(vector<int64_t> sources, vector<int64_t> targets,  
+    vector<vector<int64_t>> Routes(vector<int64_t> sources, vector<int64_t> targets,
                                int64_t graphno = 0);
 
     // shortest path distance between two points
     double Distance(int64_t src, int64_t tgt, int64_t graphno = 0);
-    
+
     // shortest path distances between list of origins and destinations
-    vector<double> Distances(vector<int64_t> sources, vector<int64_t> targets,  
+    vector<double> Distances(vector<int64_t> sources, vector<int64_t> targets,
                              int64_t graphno = 0);
 
     // precompute the range queries and reuse them

--- a/src/cyaccess.pyx
+++ b/src/cyaccess.pyx
@@ -31,6 +31,7 @@ cdef extern from "accessibility.h" namespace "MTC::accessibility":
         double Distance(int64_t, int64_t, int64_t)
         vector[double] Distances(vector[int64_t], vector[int64_t], int64_t)
         vector[vector[pair[int64_t, float]]] Range(vector[int64_t], float, int64_t, vector[int64_t])
+        vector[vector[pair[int64_t, float]]] KNearestNodes(vector[int64_t], int64_t, double, int64_t, vector[int64_t])
         void precomputeRangeQueries(double)
 
 
@@ -47,11 +48,11 @@ cdef np.ndarray[double, ndim=2] convert_2D_vector_to_array_dbl(
         vector[vector[double]] vec):
     if vec.size() == 0:
         return np.empty((0, 0), dtype=np.float64)
-    
+
     cdef int64_t rows = vec.size()
     cdef int64_t cols = vec[0].size() if rows > 0 else 0
     cdef np.ndarray[double, ndim=2] arr = np.empty((rows, cols), dtype=np.float64)
-    
+
     cdef int64_t i, j
     for i in range(rows):
         if vec[i].size() != cols:
@@ -65,11 +66,11 @@ cdef np.ndarray[int64_t, ndim=2] convert_2D_vector_to_array_int(
         vector[vector[int64_t]] vec):
     if vec.size() == 0:
         return np.empty((0, 0), dtype=np.int64)
-    
+
     cdef int64_t rows = vec.size()
     cdef int64_t cols = vec[0].size() if rows > 0 else 0
     cdef np.ndarray[int64_t, ndim=2] arr = np.empty((rows, cols), dtype=np.int64)
-    
+
     cdef int64_t i, j
     for i in range(rows):
         if vec[i].size() != cols:
@@ -121,7 +122,7 @@ cdef class cyaccess:
         category - the category name
         node_ids - an array of nodeids which are locations where this poi occurs
         """
-        
+
         self.access.initializeCategory(maxdist, maxitems, category, node_ids)
 
     def find_all_nearest_pois(
@@ -191,7 +192,7 @@ cdef class cyaccess:
         """
         return self.access.Route(srcnode, destnode, impno)
 
-    def shortest_paths(self, np.ndarray[int64_t] srcnodes, 
+    def shortest_paths(self, np.ndarray[int64_t] srcnodes,
             np.ndarray[int64_t] destnodes, int64_t impno=0):
         """
         srcnodes - node ids of origins
@@ -208,7 +209,7 @@ cdef class cyaccess:
         """
         return self.access.Distance(srcnode, destnode, impno)
 
-    def shortest_path_distances(self, np.ndarray[int64_t] srcnodes, 
+    def shortest_path_distances(self, np.ndarray[int64_t] srcnodes,
             np.ndarray[int64_t] destnodes, int64_t impno=0):
         """
         srcnodes - node ids of origins
@@ -216,11 +217,11 @@ cdef class cyaccess:
         impno - impedance id
         """
         return self.access.Distances(srcnodes, destnodes, impno)
-    
+
     def precompute_range(self, double radius):
         self.access.precomputeRangeQueries(radius)
 
-    def nodes_in_range(self, vector[int64_t] srcnodes, float radius, int64_t impno, 
+    def nodes_in_range(self, vector[int64_t] srcnodes, float radius, int64_t impno,
             np.ndarray[int64_t] ext_ids):
         """
         srcnodes - node ids of origins
@@ -229,3 +230,32 @@ cdef class cyaccess:
         ext_ids - all node ids in the network
         """
         return self.access.Range(srcnodes, radius, impno, ext_ids)
+
+    def k_nearest_nodes(self, vector[int64_t] srcnodes, int64_t k, double max_radius,
+            np.ndarray[int64_t] ext_ids, int64_t impno=0):
+        """
+        srcnodes - node ids of origins
+        k - number of nearest nodes to return per source
+        max_radius - maximum travel distance to search within
+        ext_ids - all node ids in the network
+        impno - the impedance id to use (default 0)
+
+        Returns (dists, ids): two 2-D float64/int64 arrays of shape
+        (len(srcnodes), k), containing network distances and node IDs of
+        the k nearest neighbours, sorted by ascending distance.
+        """
+        cdef vector[vector[pair[int64_t, float]]] raw = \
+            self.access.KNearestNodes(srcnodes, k, max_radius, impno, ext_ids)
+
+        cdef int64_t rows = raw.size()
+        cdef int64_t cols = k
+        cdef np.ndarray[double, ndim=2] dists = np.full((rows, cols), np.inf, dtype=np.float64)
+        cdef np.ndarray[int64_t, ndim=2] ids = np.full((rows, cols), -1, dtype=np.int64)
+        cdef int64_t i, j
+
+        for i in range(rows):
+            for j in range(<int64_t>raw[i].size()):
+                ids[i, j] = raw[i][j].first
+                dists[i, j] = raw[i][j].second
+
+        return dists, ids

--- a/src/graphalg.cpp
+++ b/src/graphalg.cpp
@@ -1,6 +1,7 @@
 #include "graphalg.h"
 #include <math.h>
 #include <cstdint>
+#include <limits>
 
 namespace MTC {
 namespace accessibility {
@@ -10,10 +11,10 @@ Graphalg::Graphalg(
     this->numnodes = numnodes;
 
     int num = omp_get_max_threads();
-    
+
     FILE_LOG(logINFO) << "Generating contraction hierarchies with "
                       << num << " threads.\n";
-    
+
     ch = CH::ContractionHierarchies(num);
 
     vector<CH::Node> nv;
@@ -27,7 +28,7 @@ Graphalg::Graphalg(
 
     FILE_LOG(logINFO) << "Setting CH node vector of size "
                       << nv.size() << "\n";
-	
+
     ch.SetNodeVector(nv);
 
     vector<CH::Edge> ev;
@@ -40,7 +41,7 @@ Graphalg::Graphalg(
 
     FILE_LOG(logINFO) << "Setting CH edge vector of size "
                       << ev.size() << "\n";
-    
+
     ch.SetEdgeVector(ev);
     ch.RunPreprocessing();
 }
@@ -93,6 +94,54 @@ void Graphalg::Range(int src, double maxdist, int threadNum,
         node.second = tmp[i].second/DISTANCEMULTFACT;
         ResultingNodes.push_back(node);
     }
+}
+
+
+DistanceVec
+Graphalg::KNearest(int src, int k, double max_radius, int threadNum) {
+    // When max_radius <= 0 (unlimited), use iterative radius doubling so we
+    // only traverse a small local neighbourhood rather than the whole network.
+    // Start at 500 m and double until k non-self neighbours are found or the
+    // safe overflow cap (4 000 km) is reached.
+    const double UNLIMITED_CAP = 4000000.0;
+    const double INITIAL_RADIUS = 500.0;
+
+    auto collect = [&](double radius) -> DistanceVec {
+        DistanceVec nodes;
+        Range(src, radius, threadNum, nodes);
+        // Remove source node (distance == 0)
+        nodes.erase(
+            std::remove_if(nodes.begin(), nodes.end(),
+                           [src](const std::pair<NodeID, float> &p) {
+                               return static_cast<int>(p.first) == src;
+                           }),
+            nodes.end());
+        return nodes;
+    };
+
+    DistanceVec all_nodes;
+    if (max_radius <= 0.0) {
+        double r = INITIAL_RADIUS;
+        while (r <= UNLIMITED_CAP) {
+            all_nodes = collect(r);
+            if (static_cast<int>(all_nodes.size()) >= k) break;
+            if (r >= UNLIMITED_CAP) break;
+            r = std::min(r * 2.0, UNLIMITED_CAP);
+        }
+    } else {
+        all_nodes = collect(max_radius);
+    }
+
+    // Partial sort: only fully sort the first k elements — O(n log k) vs O(n log n)
+    int take = std::min(k, static_cast<int>(all_nodes.size()));
+    std::partial_sort(all_nodes.begin(), all_nodes.begin() + take, all_nodes.end(),
+                      [](const std::pair<NodeID, float> &a,
+                         const std::pair<NodeID, float> &b) {
+                          return a.second < b.second;
+                      });
+    all_nodes.resize(take);
+
+    return all_nodes;
 }
 
 

--- a/src/graphalg.h
+++ b/src/graphalg.h
@@ -33,6 +33,9 @@ class Graphalg {
     void Range(int src, double maxdist, int threadNum,
                DistanceVec &ResultingNodes);
 
+    // return the k nearest nodes up to max_radius, sorted by distance
+    DistanceVec KNearest(int src, int k, double max_radius, int threadNum = 0);
+
     DistanceMap NearestPOI(const POIKeyType &category, int src, double maxdist,
                            int number, int threadNum = 0);
 

--- a/tests/test_cyaccess.py
+++ b/tests/test_cyaccess.py
@@ -97,6 +97,24 @@ def test_shortest_path(net):
     assert route.iloc[20] == 345
     assert net.shortest_path_distance(996, 71) == 23
 
+def test_k_nearest_nodes(net, nodes_and_edges):
+    nodes = nodes_and_edges[0]
+    ext_ids = nodes.index.values.astype(np.int64)
+    srcnodes = ext_ids[:5]  # test with first 5 nodes
+    k = 3
+    dists, ids = net.k_nearest_nodes(srcnodes, k, 0, ext_ids)
+    # Check output shapes
+    assert dists.shape == (5, 3)
+    assert ids.shape == (5, 3)
+    # Check that no srcnode is returned as its own neighbor
+    for i in range(5):
+        assert all(ids[i, :] != srcnodes[i])
+    # Check that distances are sorted for each srcnode
+    # (skip rows where no neighbours were found — all-inf rows are trivially sorted)
+    for i in range(5):
+        row = dists[i, :]
+        finite = row[np.isfinite(row)]
+        assert np.all(np.diff(finite) >= 0)
 
 """
 # run this and watch the memory use in activity monitor

--- a/tests/test_pandarm.py
+++ b/tests/test_pandarm.py
@@ -485,3 +485,57 @@ def test_nodes_in_range(sample_osm):
     assert (all_distances <= 1).sum() == len(test1.query(f"source == {focus_id}"))
     assert (all_distances <= 5).sum() == len(test5.query(f"source == {focus_id}"))
     assert (all_distances <= 11).sum() == len(test11.query(f"source == {focus_id}"))
+
+
+def test_k_nearest_nodes(sample_osm):
+    net = sample_osm
+
+    np.random.seed(0)
+    ssize = 10
+    x, y = random_x_y(net, ssize)
+    snaps = net.get_node_ids(x, y)
+    k = 5
+
+    result = net.k_nearest_nodes(snaps, k, max_radius=0)
+
+    # Returns a DataFrame with the expected columns
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.columns) == ["source", "destination", "weight"]
+
+    # Each source has at most k rows; sources not in result are isolated nodes
+    counts = result.groupby("source").size()
+    assert (counts <= k).all()
+
+    # No source appears as its own destination
+    assert (result["source"] == result["destination"]).sum() == 0
+
+    # Distances are non-negative
+    assert (result["weight"] >= 0).all()
+
+    # Distances are sorted ascending within each source group
+    for src, group in result.groupby("source"):
+        assert group["weight"].is_monotonic_increasing, (
+            f"Distances not sorted for source {src}"
+        )
+
+    # With a tight radius, results are a subset of the unlimited-radius results
+    result_tight = net.k_nearest_nodes(snaps, k, max_radius=5)
+    assert set(zip(result_tight["source"], result_tight["destination"])).issubset(
+        set(zip(result["source"], result["destination"]))
+    )
+    # Tight-radius distances all respect the bound
+    assert (result_tight["weight"] <= 5).all()
+
+    # Results are consistent with nodes_in_range: the k distances returned by
+    # k_nearest_nodes should equal the k smallest distances from nodes_in_range
+    # (excluding the source itself; comparing distances to be robust to tie-breaking)
+    focus_id = snaps[0]
+    if focus_id in result["source"].values:
+        knn_dists = np.sort(
+            result.loc[result["source"] == focus_id, "weight"].values
+        )
+        nir = net.nodes_in_range([focus_id], radius=2000)
+        nir_others = nir[nir["destination"] != focus_id]
+        nir_top_k_dists = np.sort(nir_others.nsmallest(k, "weight")["weight"].values)
+        assert_allclose(knn_dists, nir_top_k_dists)
+


### PR DESCRIPTION
I am writing a paper on gwlearn and would love to include adaptive kernel (KNN) derived from network distances. I have not found a reasonable way of doing that using current methods besides using `nodes_in_range` with a range large enough and then filtering it. 

This therefore introduces `k_nearest_nodes` on the Python, which works like `nodes_in_range` but returns `k` nodes, and `KNearestNodes` plus `KNearest` on the C++ side to support that search. C++/Cython bits are mostly Claude, with some guidance to avoid stupid paths.

Happy to use this from my own branch if you don't want to touch the C++ code.