### PR TITLE
Addition of exponential decay parameter

### DIFF
--- a/pandarm/network.py
+++ b/pandarm/network.py
@@ -658,7 +658,6 @@ class Network:
 
             *Additional notes:* see ``aggregateAccessibilityVariable`` in
             accessibility.cpp to read through the code that applies decays.
-            The exponential decay function is exp(-1*distance/radius)*var.
             The decay setting only operates on 'sum' and 'mean' aggregations.
             If you apply decay to a 'mean', the result will NOT be a weighted
             average; it will be the mean of the post-decay values. (So for a
@@ -676,7 +675,9 @@ class Network:
             variable name will be used so that the most recent call to set
             without giving a name will be the variable used.
         exp_constant : float, optional
-            This provides the option of setting radius (maximum distance) and exponential decay constant separately. Instead of exp(-1*distance/radius)*var, the function will be exp(-exp_constant*distance)*var .
+            This provides the option of setting maximum distance (radius) and
+            exponential decay constant separately. If this constant is not provided,
+            it defaults to 1/radius (the behaviour in previous versions of Pandana).
 
         Returns
         -------
@@ -717,7 +718,7 @@ class Network:
         if decay in ["exponential", "exp"]:
             decay = "exp"
             if exp_constant is None:
-                print("No exponential parameter provided. Exponential parameter will be 1/distance.")
+                print("No exponential parameter provided. Exponential parameter will be 1/radius.")
                 exp_constant = 1/distance
 
         res = self.net.get_all_aggregate_accessibility_variables(

--- a/pandarm/network.py
+++ b/pandarm/network.py
@@ -628,7 +628,7 @@ class Network:
         decay="linear",
         imp_name=None,
         name="tmp",
-        exp_par=None,
+        exp_constant=None,
         type=None,  # noqa: A002 - `type` builtin -- marker for removal
     ):
         """
@@ -675,8 +675,8 @@ class Network:
             and named by a call to ``set``.  If not specified, the default
             variable name will be used so that the most recent call to set
             without giving a name will be the variable used.
-        exp_par : float, optional
-            This provides the option of setting radius (maximum distance) and exponential decay constant separately. Instead of exp(-1*distance/radius)*var, the function will be exp(-exp_par*distance)*var .
+        exp_constant : float, optional
+            This provides the option of setting radius (maximum distance) and exponential decay constant separately. Instead of exp(-1*distance/radius)*var, the function will be exp(-exp_constant*distance)*var .
 
         Returns
         -------
@@ -716,9 +716,9 @@ class Network:
  
         if decay in ["exponential", "exp"]:
             decay = "exp"
-            if exp_par == None:
+            if exp_constant is None:
                 print("No exponential parameter provided. Exponential parameter will be 1/distance.")
-                exp_par = 1/distance
+                exp_constant = 1/distance
 
         res = self.net.get_all_aggregate_accessibility_variables(
             distance,
@@ -726,7 +726,7 @@ class Network:
             func,
             decay,
             imp_num,
-            exp_par if decay == "exp" else 0.0,
+            exp_constant if decay == "exp" else 0.0,
         )
 
         return pd.Series(res, index=self.node_ids)

--- a/pandarm/network.py
+++ b/pandarm/network.py
@@ -628,6 +628,7 @@ class Network:
         decay="linear",
         imp_name=None,
         name="tmp",
+        exp_par=None,
         type=None,  # noqa: A002 - `type` builtin -- marker for removal
     ):
         """
@@ -674,6 +675,8 @@ class Network:
             and named by a call to ``set``.  If not specified, the default
             variable name will be used so that the most recent call to set
             without giving a name will be the variable used.
+        exp_par : float, optional
+            This provides the option of setting radius (maximum distance) and exponential decay constant separately. Instead of exp(-1*distance/radius)*var, the function will be exp(-exp_par*distance)*var .
 
         Returns
         -------
@@ -710,6 +713,12 @@ class Network:
         assert (
             name in self.variable_names
         ), "A variable with that name has not yet been initialized"
+ 
+        if decay in ["exponential", "exp"]:
+            decay = "exp"
+            if exp_par == None:
+                print("No exponential parameter provided. Exponential parameter will be 1/distance.")
+                exp_par = 1/distance
 
         res = self.net.get_all_aggregate_accessibility_variables(
             distance,
@@ -717,6 +726,7 @@ class Network:
             func,
             decay,
             imp_num,
+            exp_par if decay == "exp" else 0.0,
         )
 
         return pd.Series(res, index=self.node_ids)

--- a/src/accessibility.cpp
+++ b/src/accessibility.cpp
@@ -275,7 +275,7 @@ Accessibility::findAllNearestPOIs(float maxradius, unsigned num_of_pois,
         }
     }
     return make_pair(dists, poi_ids);
-}
+    }
 
 
 /*
@@ -308,7 +308,8 @@ Accessibility::getAllAggregateAccessibilityVariables(
     string category,
     string aggtyp,
     string decay,
-    int64_t graphno) {
+    int64_t graphno,
+    float exp_par) {
     if (accessibilityVars.find(category) == accessibilityVars.end() ||
         std::find(aggregations.begin(), aggregations.end(), aggtyp)
             == aggregations.end() ||
@@ -329,7 +330,8 @@ Accessibility::getAllAggregateAccessibilityVariables(
             accessibilityVars[category],
             aggtyp,
             decay,
-            graphno);
+            graphno,
+            exp_par);
     }
     }
     return scores;
@@ -389,7 +391,8 @@ Accessibility::aggregateAccessibilityVariable(
     accessibility_vars_t &vars,
     string aggtyp,
     string decay,
-    int64_t gno) {
+    int64_t gno,
+    float exp_par) {
     // I don't know if this is the best way to do this but I
     // I don't want to copy memory in the precompute case - sometimes
     // I need a reference and sometimes not
@@ -430,16 +433,16 @@ Accessibility::aggregateAccessibilityVariable(
     double sum = 0.0;
     double sumsq = 0.0;
 
-    std::function<double(const double &, const float &, const float &)> sum_function;
+    std::function<double(const double &, const float &, const float &, const float &)> sum_function;
 
     if(decay == "exp")
-        sum_function = [](const double &distance, const float &radius, const float &var)
-                        { return exp(-1*distance/radius) * var; };
+        sum_function = [](const double &distance, const float &radius, const float &var, const float &exp_par)
+                        { return exp(-exp_par*distance) * var; };
     if(decay == "linear")
-        sum_function = [](const double &distance, const float &radius, const float &var)
+        sum_function = [](const double &distance, const float &radius, const float &var, const float &exp_par)
                         { return (1.0-distance/radius) * var; };
     if(decay == "flat")
-        sum_function = [](const double &distance, const float &radius, const float &var)
+        sum_function = [](const double &distance, const float &radius, const float &var, const float &exp_par)
                         { return var; };
 
     for (int64_t i = 0 ; i < distances.size() ; i++) {
@@ -451,7 +454,7 @@ Accessibility::aggregateAccessibilityVariable(
 
         for (int64_t j = 0 ; j < vars[nodeid].size() ; j++) {
             cnt++;  // count items
-            sum += sum_function(distance, radius, vars[nodeid][j]);
+            sum += sum_function(distance, radius, vars[nodeid][j], exp_par);
 
             // stddev is always flat
             sumsq += vars[nodeid][j] * vars[nodeid][j];

--- a/src/accessibility.cpp
+++ b/src/accessibility.cpp
@@ -309,7 +309,7 @@ Accessibility::getAllAggregateAccessibilityVariables(
     string aggtyp,
     string decay,
     int64_t graphno,
-    float exp_par) {
+    float exp_constant) {
     if (accessibilityVars.find(category) == accessibilityVars.end() ||
         std::find(aggregations.begin(), aggregations.end(), aggtyp)
             == aggregations.end() ||
@@ -331,7 +331,7 @@ Accessibility::getAllAggregateAccessibilityVariables(
             aggtyp,
             decay,
             graphno,
-            exp_par);
+            exp_constant);
     }
     }
     return scores;
@@ -392,7 +392,7 @@ Accessibility::aggregateAccessibilityVariable(
     string aggtyp,
     string decay,
     int64_t gno,
-    float exp_par) {
+    float exp_constant) {
     // I don't know if this is the best way to do this but I
     // I don't want to copy memory in the precompute case - sometimes
     // I need a reference and sometimes not
@@ -436,13 +436,13 @@ Accessibility::aggregateAccessibilityVariable(
     std::function<double(const double &, const float &, const float &, const float &)> sum_function;
 
     if(decay == "exp")
-        sum_function = [](const double &distance, const float &radius, const float &var, const float &exp_par)
-                        { return exp(-exp_par*distance) * var; };
+        sum_function = [](const double &distance, const float &radius, const float &var, const float &exp_constant)
+                        { return exp(-exp_constant*distance) * var; };
     if(decay == "linear")
-        sum_function = [](const double &distance, const float &radius, const float &var, const float &exp_par)
+        sum_function = [](const double &distance, const float &radius, const float &var, const float &exp_constant)
                         { return (1.0-distance/radius) * var; };
     if(decay == "flat")
-        sum_function = [](const double &distance, const float &radius, const float &var, const float &exp_par)
+        sum_function = [](const double &distance, const float &radius, const float &var, const float &exp_constant)
                         { return var; };
 
     for (int64_t i = 0 ; i < distances.size() ; i++) {
@@ -454,7 +454,7 @@ Accessibility::aggregateAccessibilityVariable(
 
         for (int64_t j = 0 ; j < vars[nodeid].size() ; j++) {
             cnt++;  // count items
-            sum += sum_function(distance, radius, vars[nodeid][j], exp_par);
+            sum += sum_function(distance, radius, vars[nodeid][j], exp_constant);
 
             // stddev is always flat
             sumsq += vars[nodeid][j] * vars[nodeid][j];

--- a/src/accessibility.h
+++ b/src/accessibility.h
@@ -44,7 +44,8 @@ class Accessibility {
         string index,
         string aggtyp,
         string decay,
-        int64_t graphno = 0);
+        int64_t graphno = 0,
+        float exp_par = 0);
 
     // get nodes with a range for a specific list of source nodes
     vector<vector<pair<int64_t, float>>> Range(vector<int64_t> srcnodes, float radius, 
@@ -117,7 +118,8 @@ class Accessibility {
         accessibility_vars_t &vars,
         string aggtyp,
         string gravity_func,
-        int64_t graphno = 0);
+        int64_t graphno = 0,
+        float exp_par = 0);
 
     double
     quantileAccessibilityVariable(

--- a/src/accessibility.h
+++ b/src/accessibility.h
@@ -45,7 +45,7 @@ class Accessibility {
         string aggtyp,
         string decay,
         int64_t graphno = 0,
-        float exp_par = 0);
+        float exp_constant = 0);
 
     // get nodes with a range for a specific list of source nodes
     vector<vector<pair<int64_t, float>>> Range(vector<int64_t> srcnodes, float radius, 
@@ -119,7 +119,7 @@ class Accessibility {
         string aggtyp,
         string gravity_func,
         int64_t graphno = 0,
-        float exp_par = 0);
+        float exp_constant = 0);
 
     double
     quantileAccessibilityVariable(

--- a/src/cyaccess.pyx
+++ b/src/cyaccess.pyx
@@ -170,7 +170,7 @@ cdef class cyaccess:
         aggtyp,
         decay,
         int64_t impno=0,
-        double exp_par=0,
+        double exp_constant=0,
     ):
         """
         radius - search radius
@@ -178,10 +178,10 @@ cdef class cyaccess:
         aggtyp - aggregation type, see docs
         decay - decay type, see docs
         impno - the impedance id to use
-        exp_par - parameter for exponential decay
+        exp_constant - parameter for exponential decay
         """
         ret = self.access.getAllAggregateAccessibilityVariables(
-            radius, category, aggtyp, decay, impno, exp_par)
+            radius, category, aggtyp, decay, impno, exp_constant)
 
         return convert_vector_to_array_dbl(ret)
 

--- a/src/cyaccess.pyx
+++ b/src/cyaccess.pyx
@@ -25,7 +25,7 @@ cdef extern from "accessibility.h" namespace "MTC::accessibility":
             float, int64_t, string, int64_t)
         void initializeAccVar(string, vector[int64_t], vector[double])
         vector[double] getAllAggregateAccessibilityVariables(
-            float, string, string, string, int64_t)
+            float, string, string, string, int64_t, float)
         vector[int64_t] Route(int64_t, int64_t, int64_t)
         vector[vector[int64_t]] Routes(vector[int64_t], vector[int64_t], int64_t)
         double Distance(int64_t, int64_t, int64_t)
@@ -170,6 +170,7 @@ cdef class cyaccess:
         aggtyp,
         decay,
         int64_t impno=0,
+        double exp_par=0,
     ):
         """
         radius - search radius
@@ -177,9 +178,10 @@ cdef class cyaccess:
         aggtyp - aggregation type, see docs
         decay - decay type, see docs
         impno - the impedance id to use
+        exp_par - parameter for exponential decay
         """
         ret = self.access.getAllAggregateAccessibilityVariables(
-            radius, category, aggtyp, decay, impno)
+            radius, category, aggtyp, decay, impno, exp_par)
 
         return convert_vector_to_array_dbl(ret)
 

--- a/tests/test_pandarm.py
+++ b/tests/test_pandarm.py
@@ -245,6 +245,50 @@ def test_non_float_node_values(sample_osm):
                 assert s.describe()["std"] > 0
 
 
+def test_exp_par_default(sample_osm):
+    # test that exponential decay parameter defaults to 1/distance
+    net = sample_osm
+
+    ssize = 75
+    np.random.seed(1)
+    net.set(random_connected_nodes(sample_osm, ssize), variable=random_data(ssize))
+
+    distance = 2000
+    implicit = net.aggregate(distance, func="sum", decay="exp")
+    explicit = net.aggregate(distance, func="sum", decay="exp", exp_par=1 / distance)
+
+    assert_allclose(implicit.values, explicit.values)
+
+
+def test_exp_par_changes_exponential_decay(sample_osm):
+    net = sample_osm
+
+    ssize = 75
+    np.random.seed(2)
+    net.set(random_connected_nodes(sample_osm, ssize), variable=random_data(ssize))
+
+    distance = 2000
+    low_decay = net.aggregate(distance, func="sum", decay="exp", exp_par=0.0001)
+    high_decay = net.aggregate(distance, func="sum", decay="exp", exp_par=0.01)
+
+    assert np.all(high_decay.values <= low_decay.values + 1e-12)
+    assert np.any(high_decay.values < low_decay.values - 1e-12)
+
+
+def test_exp_par_ignored_for_non_exponential_decay(sample_osm):
+    net = sample_osm
+
+    ssize = 75
+    np.random.seed(3)
+    net.set(random_connected_nodes(sample_osm, ssize), variable=random_data(ssize))
+
+    distance = 2000
+    linear_a = net.aggregate(distance, func="sum", decay="linear", exp_par=0.0001)
+    linear_b = net.aggregate(distance, func="sum", decay="linear", exp_par=10.0)
+
+    assert_allclose(linear_a.values, linear_b.values)
+
+
 def test_missing_nodeid(sample_osm):
     node_ids = random_node_ids(sample_osm, 50)
     # non-existing value

--- a/tests/test_pandarm.py
+++ b/tests/test_pandarm.py
@@ -245,7 +245,7 @@ def test_non_float_node_values(sample_osm):
                 assert s.describe()["std"] > 0
 
 
-def test_exp_par_default(sample_osm):
+def test_exp_constant_default(sample_osm):
     # test that exponential decay parameter defaults to 1/distance
     net = sample_osm
 
@@ -255,12 +255,12 @@ def test_exp_par_default(sample_osm):
 
     distance = 2000
     implicit = net.aggregate(distance, func="sum", decay="exp")
-    explicit = net.aggregate(distance, func="sum", decay="exp", exp_par=1 / distance)
+    explicit = net.aggregate(distance, func="sum", decay="exp", exp_constant=1 / distance)
 
     assert_allclose(implicit.values, explicit.values)
 
 
-def test_exp_par_changes_exponential_decay(sample_osm):
+def test_exp_constant_changes_exponential_decay(sample_osm):
     net = sample_osm
 
     ssize = 75
@@ -268,14 +268,14 @@ def test_exp_par_changes_exponential_decay(sample_osm):
     net.set(random_connected_nodes(sample_osm, ssize), variable=random_data(ssize))
 
     distance = 2000
-    low_decay = net.aggregate(distance, func="sum", decay="exp", exp_par=0.0001)
-    high_decay = net.aggregate(distance, func="sum", decay="exp", exp_par=0.01)
+    low_decay = net.aggregate(distance, func="sum", decay="exp", exp_constant=0.0001)
+    high_decay = net.aggregate(distance, func="sum", decay="exp", exp_constant=0.01)
 
     assert np.all(high_decay.values <= low_decay.values + 1e-12)
     assert np.any(high_decay.values < low_decay.values - 1e-12)
 
 
-def test_exp_par_ignored_for_non_exponential_decay(sample_osm):
+def test_exp_constant_ignored_for_non_exponential_decay(sample_osm):
     net = sample_osm
 
     ssize = 75
@@ -283,8 +283,8 @@ def test_exp_par_ignored_for_non_exponential_decay(sample_osm):
     net.set(random_connected_nodes(sample_osm, ssize), variable=random_data(ssize))
 
     distance = 2000
-    linear_a = net.aggregate(distance, func="sum", decay="linear", exp_par=0.0001)
-    linear_b = net.aggregate(distance, func="sum", decay="linear", exp_par=10.0)
+    linear_a = net.aggregate(distance, func="sum", decay="linear", exp_constant=0.0001)
+    linear_b = net.aggregate(distance, func="sum", decay="linear", exp_constant=10.0)
 
     assert_allclose(linear_a.values, linear_b.values)
 


### PR DESCRIPTION
Hi, I have a few modifications I've been using locally, and I think this one is simple and useful for others.

It adds an optional exponential decay constant to network.aggregate, whereas currently the radius and exponential decay constant are linked (constant = 1/radius), which doesn't work for my applications. If exponential decay is requested but the parameter is not passed, it falls back to the current 1/radius.