### PR TITLE
fixed bug when reprojection is done on a network without edge geometries

### DIFF
--- a/pandarm/loaders/osm.py
+++ b/pandarm/loaders/osm.py
@@ -137,7 +137,7 @@ def project_network(network, output_crs=None, input_crs=4326):
     #  take original x,y coordinates and convert into geopandas.Series, then reproject
     nodes = _reproject_osm_nodes(network.nodes_df, input_crs, output_crs)
     edges = network.edges_df.copy()
-    if "geometry" in edges.columns:
+    if isinstance(edges, gpd.GeoDataFrame):
         edges = edges.to_crs(output_crs)
 
     #  reinstantiate the network (needs to rebuild the tree)
@@ -148,9 +148,10 @@ def project_network(network, output_crs=None, input_crs=4326):
         edge_to=edges["to"],
         edge_weights=edges[[network.impedance_names[0]]],
         twoway=network._twoway,
+        crs=output_crs,
     )
 
-    if "geometry" in edges.columns:
+    if isinstance(edges, gpd.GeoDataFrame):
         net.edges_df = gpd.GeoDataFrame(net.edges_df, geometry=edges.geometry, crs=output_crs)
 
     net.nodes_df = gpd.GeoDataFrame(net.nodes_df, geometry=nodes.geometry, crs=output_crs)

--- a/pandarm/loaders/osm.py
+++ b/pandarm/loaders/osm.py
@@ -149,7 +149,10 @@ def project_network(network, output_crs=None, input_crs=4326):
         edge_weights=edges[[network.impedance_names[0]]],
         twoway=network._twoway,
     )
-    net.edges_df = gpd.GeoDataFrame(net.edges_df, geometry=edges.geometry, crs=output_crs)
+
+    if "geometry" in edges.columns:
+        net.edges_df = gpd.GeoDataFrame(net.edges_df, geometry=edges.geometry, crs=output_crs)
+
     net.nodes_df = gpd.GeoDataFrame(net.nodes_df, geometry=nodes.geometry, crs=output_crs)
 
     return net


### PR DESCRIPTION
This one is really trivial. When project_network is used with a pandarm.Network object without edge geometries, this would throw an error, as project_network tries to return GeoDataFrames. With this change, project_network just returns a dataframe for edges if there is no geometry column.