### PR TITLE
fix omp linking in wheel recipe

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -29,10 +29,12 @@ jobs:
           # macOS Intel (x86_64)
           - os: macos-13
             arch: x86_64
+            macosx_deployment_target: "13.0"
 
           # macOS Apple Silicon (arm64)
           - os: macos-latest
             arch: arm64
+            macosx_deployment_target: "15.0"
 
           # Windows x86_64
           - os: windows-latest
@@ -44,6 +46,8 @@ jobs:
       CIBW_BUILD: "cp311-* cp312-* cp313-*"
       CIBW_ARCHS: ${{ matrix.arch }}
       CIBW_BUILD_VERBOSITY: 1
+      # Match Homebrew libomp's minimum OS target so delocate can bundle it.
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macosx_deployment_target }}
 
       # ── Linux ──────────────────────────────────────────────────────────────
       # Install OpenMP inside the manylinux container before building.

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -80,7 +80,7 @@ jobs:
         delvewheel repair -w {dest_dir} {wheel}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Enable QEMU for Linux aarch64 cross-compilation.
       - name: Set up QEMU (Linux aarch64 only)

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -3,68 +3,168 @@ name: Build and publish to PyPI
 on:
   push:
     tags:
-      - "v*"
+      - "v*"       # v1.2.3 → PyPI, v1.2.3a1/b1/rc1 → TestPyPI
+      - "test-*"   # test-anything → build + artifact only, nothing published
   workflow_dispatch:
 
 jobs:
   build_wheels:
-    name: Build and publish wheels
+    name: Build wheels on ${{ matrix.os }}
     permissions:
-      id-token: write  # MANDATORY for trusted publishing to PyPI
-      contents: write  # MANDATORY for the Github release action
+      id-token: write   # MANDATORY for trusted publishing to PyPI
+      contents: write   # MANDATORY for the GitHub release action
+
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          # Linux x86_64 — manylinux via cibuildwheel's default container
+          - os: ubuntu-latest
+            arch: x86_64
+
+          # Linux aarch64 — emulated via QEMU
+          - os: ubuntu-latest
+            arch: aarch64
+
+          # macOS Intel (x86_64)
+          - os: macos-13
+            arch: x86_64
+
+          # macOS Apple Silicon (arm64)
+          - os: macos-latest
+            arch: arm64
+
+          # Windows x86_64
+          - os: windows-latest
+            arch: AMD64
+
     runs-on: ${{ matrix.os }}
+
     env:
-      CIBW_BUILD: "cp311-* cp312-* cp313-* cp314-*"
+      CIBW_BUILD: "cp311-* cp312-* cp313-*"
+      CIBW_ARCHS: ${{ matrix.arch }}
+      CIBW_BUILD_VERBOSITY: 1
+
+      # ── Linux ──────────────────────────────────────────────────────────────
+      # Install OpenMP inside the manylinux container before building.
+      # The shared lib ends up bundled into the wheel by auditwheel automatically.
+      CIBW_BEFORE_BUILD_LINUX: >
+        yum install -y libgomp || apt-get install -y libgomp1 || true
+
+      # ── macOS ──────────────────────────────────────────────────────────────
+      # 1. Install libomp via Homebrew so the compiler can find it.
+      # 2. Point the compiler and linker at it explicitly so delocate can see
+      #    the dylib at a known Homebrew prefix and bundle it into the wheel.
+      CIBW_BEFORE_BUILD_MACOS: >
+        brew install libomp
+      CIBW_ENVIRONMENT_MACOS: >
+        CC=clang
+        CXX=clang++
+        LDFLAGS="-L$(brew --prefix libomp)/lib"
+        CPPFLAGS="-I$(brew --prefix libomp)/include"
+        DYLD_LIBRARY_PATH="$(brew --prefix libomp)/lib"
+
+      # Force delocate to bundle libomp into the wheel so it is self-contained.
+      CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+        delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+
+      # ── Windows ────────────────────────────────────────────────────────────
+      # MSVC ships its own OpenMP runtime (vcomp); nothing extra needed.
+      # delvewheel bundles the runtime DLLs automatically.
+      CIBW_BEFORE_BUILD_WINDOWS: >
+        pip install delvewheel
+      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
+        delvewheel repair -w {dest_dir} {wheel}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
-      - name: Set up Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+      # Enable QEMU for Linux aarch64 cross-compilation.
+      - name: Set up QEMU (Linux aarch64 only)
+        if: matrix.os == 'ubuntu-latest' && matrix.arch == 'aarch64'
+        uses: docker/setup-qemu-action@v3
         with:
-          miniconda-version: "latest"
-          activate-environment: pandarm
-          environment-file: environment.yml
-          auto-activate-base: false
-          auto-update-conda: true
-
-      - name: Install cibuildwheel and twine
-        shell: bash -l {0}
-        run: |
-          conda install -y pip
-          pip install cibuildwheel twine build
+          platforms: arm64
 
       - name: Build wheels
-        shell: bash -l {0}
-        run: |
-          cibuildwheel --output-dir wheelhouse
+        uses: pypa/cibuildwheel@v2.21
+        with:
+          output-dir: wheelhouse
 
-      - name: Build source distribution
-        if: matrix.os == 'ubuntu-latest'
-        shell: bash -l {0}
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}-${{ matrix.arch }}
+          path: wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist
         run: |
+          pip install build
           python -m build --sdist --outdir wheelhouse
 
-      - name: Upload built distributions
-        uses: actions/upload-artifact@v6
+      - name: Upload sdist artifact
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
-          path: wheelhouse/*
+          name: sdist
+          path: wheelhouse/*.tar.gz
 
-      - name: Publish to PyPI
-        if: startsWith(github.ref, 'refs/tags/')
-        shell: bash -l {0}
-        run: |
-          twine upload wheelhouse/*
+  publish:
+    name: Publish to PyPI and create release
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    # Runs on any tag. test-* tags build+artifact only (no publish step fires).
+    if: startsWith(github.ref, 'refs/tags/')
 
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      # v1.2.3a1 / v1.2.3b2 / v1.2.3rc1 → TestPyPI
+      - name: Publish pre-release to TestPyPI
+        if: |
+          startsWith(github.ref_name, 'v') &&
+          (contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc'))
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/
+
+      # v1.2.3 (clean) → real PyPI
+      - name: Publish release to PyPI
+        if: |
+          startsWith(github.ref_name, 'v') &&
+          !contains(github.ref_name, 'a') &&
+          !contains(github.ref_name, 'b') &&
+          !contains(github.ref_name, 'rc')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+      # GitHub Release for any v* tag; marked pre-release when applicable
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref_name, 'v')
         uses: softprops/action-gh-release@v2
         with:
-          files: wheelhouse/*
+          prerelease: ${{ contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc') }}
+          files: dist/*
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "v*"       # v1.2.3 → PyPI, v1.2.3a1/b1/rc1 → TestPyPI
-      - "test-*"   # test-anything → build + artifact only, nothing published
   workflow_dispatch:
 
 jobs:
@@ -43,7 +42,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CIBW_BUILD: "cp311-* cp312-* cp313-*"
+      CIBW_BUILD: "cp311-* cp312-* cp313-* cp314-*"
       CIBW_ARCHS: ${{ matrix.arch }}
       CIBW_BUILD_VERBOSITY: 1
       # Match Homebrew libomp's minimum OS target so delocate can bundle it.

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -47,32 +47,32 @@ jobs:
 
       # ── Linux ──────────────────────────────────────────────────────────────
       # Install OpenMP inside the manylinux container before building.
-      # auditwheel then bundles libgomp into the wheel automatically.
+      # The shared lib ends up bundled into the wheel by auditwheel automatically.
       CIBW_BEFORE_BUILD_LINUX: >
         yum install -y libgomp || apt-get install -y libgomp1 || true
 
       # ── macOS ──────────────────────────────────────────────────────────────
-      # CIBW_ENVIRONMENT_MACOS does NOT shell-expand $(...) at parse time, so
-      # we resolve the libomp prefix in a dedicated step (below) and write it
-      # to GITHUB_ENV. Those variables are then available here as literals.
-      CIBW_BEFORE_BUILD_MACOS: brew install libomp || true
-
-      # LIBOMP_PREFIX is set in the "Resolve libomp prefix" step below.
+      # 1. Install libomp via Homebrew so the compiler can find it.
+      # 2. Point the compiler and linker at it explicitly so delocate can see
+      #    the dylib at a known Homebrew prefix and bundle it into the wheel.
+      CIBW_BEFORE_BUILD_MACOS: >
+        brew install libomp
       CIBW_ENVIRONMENT_MACOS: >
         CC=clang
         CXX=clang++
-        LDFLAGS="-L$LIBOMP_PREFIX/lib"
-        CPPFLAGS="-I$LIBOMP_PREFIX/include"
-        DYLD_LIBRARY_PATH="$LIBOMP_PREFIX/lib"
+        LDFLAGS="-L$(brew --prefix libomp)/lib"
+        CPPFLAGS="-I$(brew --prefix libomp)/include"
+        DYLD_LIBRARY_PATH="$(brew --prefix libomp)/lib"
 
-      # delocate bundles libomp.dylib into the wheel so users don't need it.
+      # Force delocate to bundle libomp into the wheel so it is self-contained.
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
         delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
 
       # ── Windows ────────────────────────────────────────────────────────────
       # MSVC ships its own OpenMP runtime (vcomp); nothing extra needed.
       # delvewheel bundles the runtime DLLs automatically.
-      CIBW_BEFORE_BUILD_WINDOWS: pip install delvewheel
+      CIBW_BEFORE_BUILD_WINDOWS: >
+        pip install delvewheel
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
         delvewheel repair -w {dest_dir} {wheel}
 
@@ -85,14 +85,6 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
-
-      # Resolve the Homebrew libomp prefix and export it so CIBW_ENVIRONMENT_MACOS
-      # can reference it as a plain variable (no subshell expansion needed).
-      - name: Resolve libomp prefix (macOS only)
-        if: runner.os == 'macOS'
-        run: |
-          brew install libomp || true
-          echo "LIBOMP_PREFIX=$(brew --prefix libomp)" >> $GITHUB_ENV
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -47,32 +47,32 @@ jobs:
 
       # ── Linux ──────────────────────────────────────────────────────────────
       # Install OpenMP inside the manylinux container before building.
-      # The shared lib ends up bundled into the wheel by auditwheel automatically.
+      # auditwheel then bundles libgomp into the wheel automatically.
       CIBW_BEFORE_BUILD_LINUX: >
         yum install -y libgomp || apt-get install -y libgomp1 || true
 
       # ── macOS ──────────────────────────────────────────────────────────────
-      # 1. Install libomp via Homebrew so the compiler can find it.
-      # 2. Point the compiler and linker at it explicitly so delocate can see
-      #    the dylib at a known Homebrew prefix and bundle it into the wheel.
-      CIBW_BEFORE_BUILD_MACOS: >
-        brew install libomp
+      # CIBW_ENVIRONMENT_MACOS does NOT shell-expand $(...) at parse time, so
+      # we resolve the libomp prefix in a dedicated step (below) and write it
+      # to GITHUB_ENV. Those variables are then available here as literals.
+      CIBW_BEFORE_BUILD_MACOS: brew install libomp || true
+
+      # LIBOMP_PREFIX is set in the "Resolve libomp prefix" step below.
       CIBW_ENVIRONMENT_MACOS: >
         CC=clang
         CXX=clang++
-        LDFLAGS="-L$(brew --prefix libomp)/lib"
-        CPPFLAGS="-I$(brew --prefix libomp)/include"
-        DYLD_LIBRARY_PATH="$(brew --prefix libomp)/lib"
+        LDFLAGS="-L$LIBOMP_PREFIX/lib"
+        CPPFLAGS="-I$LIBOMP_PREFIX/include"
+        DYLD_LIBRARY_PATH="$LIBOMP_PREFIX/lib"
 
-      # Force delocate to bundle libomp into the wheel so it is self-contained.
+      # delocate bundles libomp.dylib into the wheel so users don't need it.
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
         delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
 
       # ── Windows ────────────────────────────────────────────────────────────
       # MSVC ships its own OpenMP runtime (vcomp); nothing extra needed.
       # delvewheel bundles the runtime DLLs automatically.
-      CIBW_BEFORE_BUILD_WINDOWS: >
-        pip install delvewheel
+      CIBW_BEFORE_BUILD_WINDOWS: pip install delvewheel
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
         delvewheel repair -w {dest_dir} {wheel}
 
@@ -85,6 +85,14 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
+
+      # Resolve the Homebrew libomp prefix and export it so CIBW_ENVIRONMENT_MACOS
+      # can reference it as a plain variable (no subshell expansion needed).
+      - name: Resolve libomp prefix (macOS only)
+        if: runner.os == 'macOS'
+        run: |
+          brew install libomp || true
+          echo "LIBOMP_PREFIX=$(brew --prefix libomp)" >> $GITHUB_ENV
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,12 @@ if sys.platform.startswith("darwin"):  # Mac
     # try to detect if people are using another alternative like Homebrew.
 
     if "CC" in os.environ:
-        extra_compile_args += ["-fopenmp"]
+        extra_compile_args += ["-Xpreprocessor", "-fopenmp"]
+        extra_link_args += ["-lomp"]
+        # Respect any library path injected by cibuildwheel via LDFLAGS
+        ldflags = os.environ.get("LDFLAGS", "")
+        if ldflags:
+            extra_link_args += ldflags.split()
         print(
             "Attempting pandarm compilation with OpenMP multi-threading "
             "support, with user-specified compiler:\n{}".format(os.environ["CC"])


### PR DESCRIPTION
- use native OS dev tools instead of conda
- change macos linking args in setup
- allow pushing to the testing.pypi so we dont need to increment versions when debugging this

the builds [are working](https://github.com/knaaptime/pandarm/actions/runs/26922514600/job/79425752342) and in can install/import in a fresh environment, so this should resolve #58. Probably worth doing a new release to get the wheels propagated